### PR TITLE
Adjust warmup schedule and beta start

### DIFF
--- a/scripts/train_memory_only.py
+++ b/scripts/train_memory_only.py
@@ -12,8 +12,8 @@ attn, st, dev, dty = build_fused_v2(cfg)
 torch.manual_seed(0)
 
 # Warm-up hyper-params
-warmup_steps = 2000  # purely local path
-beta_start = -4.0    # σ≈0.018 (~98% local)
+warmup_steps = 500   # purely local path
+beta_start = -1.5    # σ≈0.2 (~88% local)
 beta_target = -0.85  # σ≈0.3 mid-mix
 
 tau_start = 1.0


### PR DESCRIPTION
## Summary
- raise `beta_start` closer to -1.5 for earlier global attention
- cut warmup steps to 500 for faster transition

## Testing
- `python scripts/train_memory_only.py` *(fails: ModuleNotFoundError: No module named 'torch')*
- `nvidia-smi` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689f27bdd09c832c8f4c60340959f3e4