### PR TITLE
Log use_local mean after routing decision

### DIFF
--- a/fused_attn_v2/fused_v2.py
+++ b/fused_attn_v2/fused_v2.py
@@ -413,6 +413,9 @@ class FusedAttentionV2(nn.Module):
         p_skip = self.router(QL)  # [Bsz, H]
         use_local = (p_skip <= self.tau_skip).unsqueeze(-1)  # [Bsz,H,1] boolean mask
 
+        # Log fraction of heads using the local path for monitoring.
+        print(f"use_local mean: {use_local.float().mean().item():.4f}")
+
         # Routing mask over the window positions: [Bsz,1,w]
         routed_mask = state.routed_mask(QL, self.k_top)  # [Bsz,1,w]
         # Exclude the slot just written (self) to avoid trivial copy-attention


### PR DESCRIPTION
## Summary
- log `use_local` mean in `FusedAttentionV2.forward` for monitoring

## Testing
- `python - <<'PY' ...` *(fails: ModuleNotFoundError: No module named 'torch')*
- `pip install torch -q` *(fails: Could not find a version that satisfies the requirement torch)*

------
https://chatgpt.com/codex/tasks/task_b_689f27bf718c832c8bfd5a58e1373726